### PR TITLE
Updates to allow insert at cursor position

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,52 @@ export class AppComponent {
 }
 ```
 
+## Insert Content at Cursor position
+import MonacoEditor and also supply at providers (eg: on app.module.ts):
+```typescript
+import { BrowserModule } from '@angular/platform-browser';
+import { NgModule } from '@angular/core';
+
+import { AppComponent } from './app.component';
+import { MonacoEditorModule, MonacoEditor } from 'ngx-monaco-editor';
+
+@NgModule({
+  declarations: [
+    AppComponent
+  ],
+  imports: [
+    BrowserModule,
+    MonacoEditorModule
+  ],
+  providers: [MonacoEditor],
+  bootstrap: [AppComponent]
+})
+export class AppModule {
+}
+```
+import MonacoEditor and define at constructor (eg: on app.component.ts):
+```typescript
+import { Component } from '@angular/core';
+import { MonacoEditor } from 'ngx-monaco-editor';
+
+@Component({
+  selector: 'app-root',
+  templateUrl: './app.component.html'
+})
+export class AppComponent {
+  editorOptions = {theme: 'vs-dark', language: 'javascript'};
+  code: string= 'function x() {\nconsole.log("Hello world!");\n}';
+
+  onInsertContentClick() {
+    this.monacoEditor.insert('<p>This is the default content</p>');
+  }
+
+  constructor(
+    private monacoEditor: MonacoEditor
+  ) { }
+}
+```
+
 ## Links
 [Monaco Editor](https://github.com/Microsoft/monaco-editor/)<br/>
 [Monaco Editor Options](https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.ieditorconstructionoptions.html)

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ export class AppComponent {
 }
 ```
 
-## Insert Content at Cursor position
+### Insert Content at Cursor position
 import MonacoEditor and also supply at providers (eg: on app.module.ts):
 ```typescript
 import { BrowserModule } from '@angular/platform-browser';

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { MonacoEditor } from '../platform/editor/editor.module';
 declare const monaco: any;
 
 @Component({
@@ -8,6 +9,7 @@ declare const monaco: any;
       Welcome to {{title}}!!
     </h1>
     <button (click)="updateOptions()">Change Language</button>
+    <button (click)="onInsertContentClick()">Insert Content</button>
     <ngx-monaco-editor [options]="options" [(ngModel)]="code" (onInit)="onInit($event)"></ngx-monaco-editor>
     <pre>{{code}}</pre>
   `,
@@ -63,4 +65,12 @@ return {RenderType_AppComponent:RenderType_AppComponent,View_AppComponent_0:View
     var op = {identifier: id, range: range, text: text, forceMoveMarkers: true};
     editor.executeEdits("my-source", [op]);
   }
+
+  onInsertContentClick() {
+    this.monacoEditor.insert('<p>This is the default content</p>');
+  }
+
+  constructor(
+    private monacoEditor: MonacoEditor
+  ) { }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,7 +2,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 
 import { AppComponent } from './app.component';
-import { MonacoEditorModule } from '../platform/editor/editor.module';
+import { MonacoEditorModule, MonacoEditor } from '../platform/editor/editor.module';
 import { FormsModule } from '@angular/forms';
 
 @NgModule({
@@ -14,7 +14,7 @@ import { FormsModule } from '@angular/forms';
     FormsModule,
     MonacoEditorModule
   ],
-  providers: [],
+  providers: [MonacoEditor],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/platform/editor/editor.component.ts
+++ b/src/platform/editor/editor.component.ts
@@ -5,6 +5,7 @@ import { Observable } from 'rxjs/Rx';
 
 let loadedMonaco: boolean = false;
 let loadPromise: Promise<void>;
+let monacoEditor: any;
 declare const monaco: any;
 declare const require: any;
 
@@ -125,6 +126,7 @@ export class EditorComponent implements AfterViewInit, ControlValueAccessor {
       this._windowResizeSubscription.unsubscribe();
     }
     this._windowResizeSubscription = Observable.fromEvent(window, 'resize').subscribe(() => this._editor.layout());
+    monacoEditor = this._editor;
     this.onInit.emit(this._editor);
   }
 
@@ -137,4 +139,21 @@ export class EditorComponent implements AfterViewInit, ControlValueAccessor {
       this._editor = undefined;
     }
   }
+}
+
+export class EditorComponentHelper {
+
+  insert(insert: string) {
+    if (insert !== null && loadedMonaco) {
+      const position = monacoEditor.getPosition();
+      const range = new monaco.Range(position.lineNumber, position.column, position.lineNumber, position.column);
+      const id = { major: 1, minor: 1 };
+      const op = {identifier: id, range: range, text: insert, forceMoveMarkers: false };
+      monacoEditor.executeEdits(insert, [op]);
+      return true;
+    } else {
+      return false;
+    }
+  }
+
 }

--- a/src/platform/editor/editor.module.ts
+++ b/src/platform/editor/editor.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { EditorComponent } from './editor.component';
+import { EditorComponent, EditorComponentHelper } from './editor.component';
 
 @NgModule({
   imports: [
@@ -15,3 +15,6 @@ import { EditorComponent } from './editor.component';
 })
 export class MonacoEditorModule {
 }
+export class MonacoEditor extends EditorComponentHelper {
+}
+


### PR DESCRIPTION
## Insert Content at Cursor position
import MonacoEditor and also supply at providers (eg: on app.module.ts):
```typescript
import { BrowserModule } from '@angular/platform-browser';
import { NgModule } from '@angular/core';

import { AppComponent } from './app.component';
import { MonacoEditorModule, MonacoEditor } from 'ngx-monaco-editor';

@NgModule({
  declarations: [
    AppComponent
  ],
  imports: [
    BrowserModule,
    MonacoEditorModule
  ],
  providers: [MonacoEditor],
  bootstrap: [AppComponent]
})
export class AppModule {
}
```
import MonacoEditor and define at constructor (eg: on app.component.ts):
```typescript
import { Component } from '@angular/core';
import { MonacoEditor } from 'ngx-monaco-editor';

@Component({
  selector: 'app-root',
  templateUrl: './app.component.html'
})
export class AppComponent {
  editorOptions = {theme: 'vs-dark', language: 'javascript'};
  code: string= 'function x() {\nconsole.log("Hello world!");\n}';

  onInsertContentClick() {
    this.monacoEditor.insert('<p>This is the default content</p>');
  }

  constructor(
    private monacoEditor: MonacoEditor
  ) { }
}
```
