### PR TITLE
Handled disparate require versions as when using electron

### DIFF
--- a/src/platform/editor/editor.component.ts
+++ b/src/platform/editor/editor.component.ts
@@ -74,6 +74,10 @@ export class EditorComponent implements AfterViewInit, ControlValueAccessor {
   }
 
   ngAfterViewInit(): void {
+
+    let nodeRequire: any = (<any>window).require;
+    let amdRequire: any;
+
     if (loadedMonaco) {
       // Wait until monaco editor is available
       loadPromise.then(() => {
@@ -87,9 +91,11 @@ export class EditorComponent implements AfterViewInit, ControlValueAccessor {
           return;
         }
         let onGotAmdLoader: any = () => {
+          amdRequire = (<any>window).require;
+          (<any>window).require = nodeRequire;
           // Load monaco
-          (<any>window).require.config({ paths: { 'vs': 'assets/monaco/vs' } });
-          (<any>window).require(['vs/editor/editor.main'], () => {
+          amdRequire.require.config({ paths: { 'vs': 'assets/monaco/vs' } });
+          amdRequire.require(['vs/editor/editor.main'], () => {
             this.initMonaco(this.options);
             resolve();
           });


### PR DESCRIPTION
Wanted to adopt this component in an electron app but there was an issue because of monaco's loader.js modifying the global require.

This is currently the suggested workaround for using monaco with electron apps. (See: https://github.com/Microsoft/monaco-editor-samples/blob/master/sample-electron/index.html)

This fix won't affect non-electron apps. Hope you'll consider pulling this.