### PR TITLE
Fix loader location

### DIFF
--- a/src/platform/editor/editor.component.ts
+++ b/src/platform/editor/editor.component.ts
@@ -88,7 +88,7 @@ export class EditorComponent implements AfterViewInit, ControlValueAccessor {
         }
         let onGotAmdLoader: any = () => {
           // Load monaco
-          (<any>window).require.config({ paths: { 'vs': 'assets/monaco/vs' } });
+          (<any>window).require.config({ paths: { 'vs': '/assets/monaco/vs' } });
           (<any>window).require(['vs/editor/editor.main'], () => {
             this.initMonaco(this.options);
             resolve();
@@ -99,7 +99,7 @@ export class EditorComponent implements AfterViewInit, ControlValueAccessor {
         if (!(<any>window).require) {
           let loaderScript: HTMLScriptElement = document.createElement('script');
           loaderScript.type = 'text/javascript';
-          loaderScript.src = 'assets/monaco/vs/loader.js';
+          loaderScript.src = '/assets/monaco/vs/loader.js';
           loaderScript.addEventListener('load', onGotAmdLoader);
           document.body.appendChild(loaderScript);
         } else {


### PR DESCRIPTION
When `ngx-monaco-editor` is used in an application that doesn't use # for in-app paths, it causes `loader.js` to try to be downloaded from the wrong location (relative to the current location instead of base).

This fixes it.