### PR TITLE
Allow the assumption that options is always an object.

### DIFF
--- a/src/platform/editor/base-editor.ts
+++ b/src/platform/editor/base-editor.ts
@@ -23,7 +23,7 @@ export abstract class BaseEditor implements AfterViewInit, OnDestroy {
   }
 
   get options(): any {
-    return this._options;
+    return this._options || {};
   }
 
   constructor(private config: NgxMonacoEditorConfig) {}


### PR DESCRIPTION
Fixes issue where we are attempting assign the value to an undefined member of options when options has not yet been assigned.