### PR TITLE
Allowing editor to inherit height

### DIFF
--- a/src/platform/editor/editor.component.ts
+++ b/src/platform/editor/editor.component.ts
@@ -13,7 +13,6 @@ import { fromEvent } from 'rxjs';
   styles: [`
     :host {
       display: block;
-      height: 200px;
     }
 
     .editor-container {


### PR DESCRIPTION
Currently, the editor has a max height due to a hard-coded style property.

Removing it allows the editor to take all the available height.