### PR TITLE
add relativ default path for loading monaco-editor

### DIFF
--- a/projects/editor/src/lib/base-editor.ts
+++ b/projects/editor/src/lib/base-editor.ts
@@ -37,7 +37,7 @@ export abstract class BaseEditor implements AfterViewInit, OnDestroy {
     } else {
       loadedMonaco = true;
       loadPromise = new Promise<void>((resolve: any) => {
-        const baseUrl = this.config.baseUrl || '/assets';
+        const baseUrl = this.config.baseUrl || './assets';
         if (typeof ((<any>window).monaco) === 'object') {
           resolve();
           return;


### PR DESCRIPTION
I'm loading the ngx-monaco-editor under different root paths.
Therefore I have to configure the lib as follows:
`const monacoConfig: NgxMonacoEditorConfig = {
  baseUrl: './assets',
};`
It would be nice if the default configuration in the base-editor.ts could use a relative path instead the absolut one:
`const baseUrl = this.config.baseUrl || '/assets';`
This way I could get rid of the configuration and use ngx-monaco-editor as is.