### PR TITLE
Resizing logic should pass in the parent element

### DIFF
--- a/projects/editor/src/lib/diff-editor.component.ts
+++ b/projects/editor/src/lib/diff-editor.component.ts
@@ -72,7 +72,8 @@ export class DiffEditorComponent extends BaseEditor {
     if (this._windowResizeSubscription) {
       this._windowResizeSubscription.unsubscribe();
     }
-    this._windowResizeSubscription = fromEvent(window, 'resize').subscribe(() => this._editor.layout());
+    this._windowResizeSubscription = fromEvent(window, 'resize').subscribe(
+      () => this._editor.layout(this._editorContainer.nativeElement));
     this.onInit.emit(this._editor);
   }
 

--- a/projects/editor/src/lib/editor.component.ts
+++ b/projects/editor/src/lib/editor.component.ts
@@ -98,7 +98,8 @@ export class EditorComponent extends BaseEditor implements ControlValueAccessor 
     if (this._windowResizeSubscription) {
       this._windowResizeSubscription.unsubscribe();
     }
-    this._windowResizeSubscription = fromEvent(window, 'resize').subscribe(() => this._editor.layout());
+    this._windowResizeSubscription = fromEvent(window, 'resize').subscribe(
+      () => this._editor.layout(this._editorContainer.nativeElement));
     this.onInit.emit(this._editor);
   }
 


### PR DESCRIPTION
When calling editor.layout, the parent element should be passed in for properly recalculating available bounds.