### PR TITLE
Fix missing sourceMap in PROD and relative default assets folder

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -21,11 +21,18 @@
             "assets": [
               "projects/editor-tester/src/favicon.ico",
               "projects/editor-tester/src/assets",
-              { "glob": "**/*", "input": "node_modules/monaco-editor/min", "output": "./assets/monaco/" }
+              {
+                "glob": "**/*",
+                "input": "node_modules/monaco-editor/min",
+                "output": "./assets/monaco/min"
+              },
+              {
+                "glob": "**/*",
+                "input": "node_modules/monaco-editor/min-maps",
+                "output": "./assets/monaco/min-maps"
+              }
             ],
-            "styles": [
-              "projects/editor-tester/src/styles.css"
-            ],
+            "styles": ["projects/editor-tester/src/styles.css"],
             "scripts": [],
             "es5BrowserSupport": true
           },
@@ -80,9 +87,7 @@
               "projects/editor-tester/tsconfig.app.json",
               "projects/editor-tester/tsconfig.spec.json"
             ],
-            "exclude": [
-              "**/node_modules/**"
-            ]
+            "exclude": ["**/node_modules/**"]
           }
         }
       }
@@ -107,9 +112,7 @@
               "projects/editor/tsconfig.lib.json",
               "projects/editor/tsconfig.spec.json"
             ],
-            "exclude": [
-              "**/node_modules/**"
-            ]
+            "exclude": ["**/node_modules/**"]
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "copy:typings": "cp node_modules/monaco-editor/monaco.d.ts projects/editor/src/lib",
     "copy:types": "cp node_modules/monaco-editor/monaco.d.ts dist/editor",
     "copy:readme": "cp -rf README.md projects/editor/",
-    "copy:editor": "mkdir ./dist/editor/assets && cp -rf node_modules/monaco-editor/min dist/editor/assets/monaco"
+    "copy:editor": "mkdir ./dist/editor/assets && cp -rf node_modules/monaco-editor/min dist/editor/assets/monaco/min && cp -rf node_modules/monaco-editor/min-maps dist/editor/assets/monaco/min-maps"
   },
   "private": false,
   "repository": {

--- a/projects/editor/src/lib/base-editor.ts
+++ b/projects/editor/src/lib/base-editor.ts
@@ -1,19 +1,27 @@
-import { AfterViewInit, ElementRef, EventEmitter, Input, OnDestroy, Output, ViewChild } from '@angular/core';
-import { Subscription } from 'rxjs';
-import { NgxMonacoEditorConfig } from './config';
+import {
+  AfterViewInit,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  Output,
+  ViewChild
+} from "@angular/core";
+import { Subscription } from "rxjs";
+import { NgxMonacoEditorConfig } from "./config";
 
 let loadedMonaco = false;
 let loadPromise: Promise<void>;
 declare const require: any;
 
 export abstract class BaseEditor implements AfterViewInit, OnDestroy {
-  @ViewChild('editorContainer') _editorContainer: ElementRef;
+  @ViewChild("editorContainer") _editorContainer: ElementRef;
   @Output() onInit = new EventEmitter<any>();
   protected _editor: any;
   private _options: any;
   protected _windowResizeSubscription: Subscription;
 
-  @Input('options')
+  @Input("options")
   set options(options: any) {
     this._options = Object.assign({}, this.config.defaultOptions, options);
     if (this._editor) {
@@ -37,16 +45,18 @@ export abstract class BaseEditor implements AfterViewInit, OnDestroy {
     } else {
       loadedMonaco = true;
       loadPromise = new Promise<void>((resolve: any) => {
-        const baseUrl = this.config.baseUrl || '/assets';
-        if (typeof ((<any>window).monaco) === 'object') {
+        const baseUrl = this.config.baseUrl || "./assets";
+        if (typeof (<any>window).monaco === "object") {
           resolve();
           return;
         }
         const onGotAmdLoader: any = () => {
           // Load monaco
-          (<any>window).require.config({ paths: { 'vs': `${baseUrl}/monaco/vs` } });
-          (<any>window).require(['vs/editor/editor.main'], () => {
-            if (typeof this.config.onMonacoLoad === 'function') {
+          (<any>window).require.config({
+            paths: { vs: `${baseUrl}/monaco/vs` }
+          });
+          (<any>window).require(["vs/editor/editor.main"], () => {
+            if (typeof this.config.onMonacoLoad === "function") {
               this.config.onMonacoLoad();
             }
             this.initMonaco(this.options);
@@ -56,10 +66,12 @@ export abstract class BaseEditor implements AfterViewInit, OnDestroy {
 
         // Load AMD loader if necessary
         if (!(<any>window).require) {
-          const loaderScript: HTMLScriptElement = document.createElement('script');
-          loaderScript.type = 'text/javascript';
+          const loaderScript: HTMLScriptElement = document.createElement(
+            "script"
+          );
+          loaderScript.type = "text/javascript";
           loaderScript.src = `${baseUrl}/monaco/vs/loader.js`;
-          loaderScript.addEventListener('load', onGotAmdLoader);
+          loaderScript.addEventListener("load", onGotAmdLoader);
           document.body.appendChild(loaderScript);
         } else {
           onGotAmdLoader();

--- a/projects/editor/src/lib/base-editor.ts
+++ b/projects/editor/src/lib/base-editor.ts
@@ -53,7 +53,7 @@ export abstract class BaseEditor implements AfterViewInit, OnDestroy {
         const onGotAmdLoader: any = () => {
           // Load monaco
           (<any>window).require.config({
-            paths: { vs: `${baseUrl}/monaco/vs` }
+            paths: { vs: `${baseUrl}/monaco/min/vs` }
           });
           (<any>window).require(["vs/editor/editor.main"], () => {
             if (typeof this.config.onMonacoLoad === "function") {
@@ -70,7 +70,7 @@ export abstract class BaseEditor implements AfterViewInit, OnDestroy {
             "script"
           );
           loaderScript.type = "text/javascript";
-          loaderScript.src = `${baseUrl}/monaco/vs/loader.js`;
+          loaderScript.src = `${baseUrl}/monaco/min/vs/loader.js`;
           loaderScript.addEventListener("load", onGotAmdLoader);
           document.body.appendChild(loaderScript);
         } else {


### PR DESCRIPTION
Changed the base-editor to use default the relative "assets" folder.

Included min-maps from monaco to be exposed as assets. 

Changed structure to be /monaco/min & /monaco/min-maps. Base-editor loads from /monaco/min