### PR TITLE
#196: Fixed angular version references.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,24 +25,7 @@ For angular version 6 use v6.x.x
 npm install ngx-monaco-editor@6.0.0 --save
  ```
  
-Add the glob to assets in `.angular-cli.json` schema - `projects.[project-name].architect.build` (to make monaco-editor lib available to the app):
-```typescript
-{
-  "options": {
-    {
-      "assets": [
-        { "glob": "**/*", "input": "node_modules/ngx-monaco-editor/assets/monaco", "output": "./assets/monaco/" }
-      ],
-      ...
-    }
-    ...
-  },
-  ...
-}
- ```
-
-
-For Angular 6 and below, add the glob to assets in `angular.json`
+Add the glob to assets in `angular.json`
 ```typescript
 {
   "apps": [
@@ -54,6 +37,22 @@ For Angular 6 and below, add the glob to assets in `angular.json`
     }
     ...
   ],
+  ...
+}
+ ```
+
+For Angular 6 and below, add the glob to assets in `.angular-cli.json` schema - `projects.[project-name].architect.build` (to make monaco-editor lib available to the app):
+```typescript
+{
+  "options": {
+    {
+      "assets": [
+        { "glob": "**/*", "input": "node_modules/ngx-monaco-editor/assets/monaco", "output": "./assets/monaco/" }
+      ],
+      ...
+    }
+    ...
+  },
   ...
 }
  ```


### PR DESCRIPTION
Fixes #196: `angular.json` is now the default (moved to the top) whereas `angular-cli.json` is only relevant for Angular 6.x or below.